### PR TITLE
Support unquote-splicing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Atoms are parsed as strings. String literals delimited by `"` are parsed into
 `String` objects to make them distinct from the other atoms. Escape sequences
 `\"`, `\\`, `\n`, `\r`, `\t`, `\f`, and `\b` are supported.
 
-Supports quote, quasiquote and unquote, with `'`, `` ` `` and `,`.
+Supports quote, quasiquote, unquote and unquote-splicing, with `'`, `` ` ``,
+`,` and `,@`.
 
 ### Syntax
 
@@ -14,7 +15,7 @@ The parser reads one expression. Anything after the first complete expression
 is a syntax error. The PEG looks like this:
 
     Expr       <- Space* Expr Space* / Quoted / Atom / List
-    Quoted     <- ('\'' / '`' / ',') Expr
+    Quoted     <- ('\'' / '`' / ',' / ',@') Expr
     Atom       <- String / Symbol
     List       <- '(' Expr* ')'
     String     <- '"' ('\\"' / (Char !'"'))* '"'
@@ -35,6 +36,7 @@ is a syntax error. The PEG looks like this:
     console.log(Parse("(a 'b 'c)")); // ['a', ['quote' 'b'], ['quote', 'c']]
     console.log(Parse("(a '(b c))")); // ['a', ['quote', 'b', 'c']]
     console.log(Parse("(a `(b ,c))")); // ['a', ['quasiquote', 'b', ['unquote', 'c']]]
+    console.log(Parse("(a `(b ,@c))")); // ['a', ['quasiquote', 'b', ['unquoteSplicing', 'c']]]
 
 
 #### License

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ is a syntax error. The PEG looks like this:
     console.log(Parse("(a 'b 'c)")); // ['a', ['quote' 'b'], ['quote', 'c']]
     console.log(Parse("(a '(b c))")); // ['a', ['quote', 'b', 'c']]
     console.log(Parse("(a `(b ,c))")); // ['a', ['quasiquote', 'b', ['unquote', 'c']]]
-    console.log(Parse("(a `(b ,@c))")); // ['a', ['quasiquote', 'b', ['unquoteSplicing', 'c']]]
+    console.log(Parse("(a `(b ,@c))")); // ['a', ['quasiquote', 'b', ['unquote-splicing', 'c']]]
 
 
 #### License

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ function quoted() {
 
     if (quote == "unquote" && this.peek() == "@") {
         this.consume();
-        quote = "unquoteSplicing";
+        quote = "unquote-splicing";
     }
 
     // ignore whitespace

--- a/index.js
+++ b/index.js
@@ -164,6 +164,11 @@ function quoted() {
     var q = this.consume();
     var quote = quotes_map[q];
 
+    if (quote == "unquote" && this.peek() == "@") {
+        this.consume();
+        quote = "unquoteSplicing";
+    }
+
     // ignore whitespace
     this.until(not_whitespace_or_end);
     var quotedExpr = this.expr();

--- a/test.js
+++ b/test.js
@@ -16,10 +16,10 @@ assert.deepEqual(SParse("((a ,b ,c))"), [['a',['unquote','b'],['unquote','c']]])
 assert.deepEqual(SParse("(a ,(a b c))"), ['a', ['unquote', 'a', 'b', 'c']]);
 assert.deepEqual(SParse("(a , (a b c))"), ['a', ['unquote', 'a', 'b', 'c']]);
 assert.deepEqual(SParse("(a ,, (a b c))"), ['a', ['unquote', ['unquote', 'a', 'b', 'c']]], 'Multiple unquotes should not be flattened');
-assert.deepEqual(SParse("((a ,@b ,@c))"), [['a',['unquoteSplicing','b'],['unquoteSplicing','c']]]);
-assert.deepEqual(SParse("(a ,@(a b c))"), ['a', ['unquoteSplicing', 'a', 'b', 'c']]);
-assert.deepEqual(SParse("(a ,@ (a b c))"), ['a', ['unquoteSplicing', 'a', 'b', 'c']]);
-assert.deepEqual(SParse("(a ,@,@ (a b c))"), ['a', ['unquoteSplicing', ['unquoteSplicing', 'a', 'b', 'c']]], 'Multiple unquoteSplicings should not be flattened');
+assert.deepEqual(SParse("((a ,@b ,@c))"), [['a',['unquote-splicing','b'],['unquote-splicing','c']]]);
+assert.deepEqual(SParse("(a ,@(a b c))"), ['a', ['unquote-splicing', 'a', 'b', 'c']]);
+assert.deepEqual(SParse("(a ,@ (a b c))"), ['a', ['unquote-splicing', 'a', 'b', 'c']]);
+assert.deepEqual(SParse("(a ,@,@ (a b c))"), ['a', ['unquote-splicing', ['unquote-splicing', 'a', 'b', 'c']]], 'Multiple unquote-splicings should not be flattened');
 assert(SParse("()()") instanceof SyntaxError, 'Any character after a complete expression should be an error');
 assert(SParse("((a) b))") instanceof SyntaxError, 'Any character after a complete expression should be an error');
 assert(SParse("((a))abc") instanceof SyntaxError, 'Any character after a complete expression should be an error');

--- a/test.js
+++ b/test.js
@@ -16,6 +16,10 @@ assert.deepEqual(SParse("((a ,b ,c))"), [['a',['unquote','b'],['unquote','c']]])
 assert.deepEqual(SParse("(a ,(a b c))"), ['a', ['unquote', 'a', 'b', 'c']]);
 assert.deepEqual(SParse("(a , (a b c))"), ['a', ['unquote', 'a', 'b', 'c']]);
 assert.deepEqual(SParse("(a ,, (a b c))"), ['a', ['unquote', ['unquote', 'a', 'b', 'c']]], 'Multiple unquotes should not be flattened');
+assert.deepEqual(SParse("((a ,@b ,@c))"), [['a',['unquoteSplicing','b'],['unquoteSplicing','c']]]);
+assert.deepEqual(SParse("(a ,@(a b c))"), ['a', ['unquoteSplicing', 'a', 'b', 'c']]);
+assert.deepEqual(SParse("(a ,@ (a b c))"), ['a', ['unquoteSplicing', 'a', 'b', 'c']]);
+assert.deepEqual(SParse("(a ,@,@ (a b c))"), ['a', ['unquoteSplicing', ['unquoteSplicing', 'a', 'b', 'c']]], 'Multiple unquoteSplicings should not be flattened');
 assert(SParse("()()") instanceof SyntaxError, 'Any character after a complete expression should be an error');
 assert(SParse("((a) b))") instanceof SyntaxError, 'Any character after a complete expression should be an error');
 assert(SParse("((a))abc") instanceof SyntaxError, 'Any character after a complete expression should be an error');


### PR DESCRIPTION
Since `unquote` (`,`) is in here, I figure `unquoteSplicing` (`,@`) should be too.

(I'm writing an S-expression syntax for ECMAScript and the macros need this.)