### PR TITLE
Use parsimmon as parser abstraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,17 @@
     "email": "frodenius@gmail.com"
   },
   "contributors": [
-    {"name": "Matt Brennan", "email": "mattyb1000@gmail.com"},
-    {"name": "An", "email": "an@cyan.io"}
+    {
+      "name": "Matt Brennan",
+      "email": "mattyb1000@gmail.com"
+    },
+    {
+      "name": "An",
+      "email": "an@cyan.io"
+    }
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "parsimmon": "^0.7.0"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -33,8 +33,8 @@ assert.deepEqual(SParse("(a'b)"), ['a', ['quote', 'b']], 'Quote should act symbo
 assert.deepEqual(SParse("(a`b)"), ['a', ['quasiquote', 'b']], 'Quasiquote should act symbol delimiting');
 assert.deepEqual(SParse("(a,b)"), [ 'a', ['unquote', 'b']], 'Unquote should act symbol delimiting');
 assert.deepEqual(SParse("(a,@b)"), ['a', ['unquote-splicing', 'b']], 'Unquote-splicing should act symbol delimiting');
-assert.deepEqual(SParse("(a\\'b)"), ['a\'b'], 'Escaped quotes in symbols should parse');
-assert.deepEqual(SParse("(a\\\"b)"), ['a\"b'], 'Escaped quotes in symbols should parse');
+assert.deepEqual(SParse("(a\\'b)"), ['a\'b'], 'Escaped single quotes in symbols should parse');
+assert.deepEqual(SParse("(a\\\"b)"), ['a\"b'], 'Escaped double quotes in symbols should parse');
 assert.deepEqual(SParse("(a\\\\b)"), ['a\\b'], 'Escaped \\ in symbols should parse as \\');
 assert.deepEqual(SParse("(a\\b)"), ['ab'], 'Escaped normal characters in symbols should parse as normal');
 


### PR DESCRIPTION
Total rewrite with [parsimmon](https://github.com/jneen/parsimmon) as a parser abstraction. Less code → more maintainable. Same tests pass.